### PR TITLE
Fix GitHub Pages deploy path issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build
+          publish_dir: ./website/build/babel
           user_name: QubitPi
           user_email: jack20191124@proton.me

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ yarn && yarn bootstrap
 $ yarn build:docusaurus
 ```
 
-Then a GitHub Pages deployable will be generated under `website/build` directory
+Then a GitHub Pages deployable will be generated under `website/build/babel` directory
 
 ### Contributing to the website
 


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Fixed 404 due to the wrong pick-up path of generated website root

<img width="1778" alt="page 2" src="https://user-images.githubusercontent.com/16126939/221143765-1332ad16-7be4-48e9-9a92-c2fd552adc56.png">

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
